### PR TITLE
Ct/proxy server

### DIFF
--- a/.github/workflows/e2e-cypress-mx-adapter-proxy.yml
+++ b/.github/workflows/e2e-cypress-mx-adapter-proxy.yml
@@ -1,0 +1,88 @@
+name: E2E Tests (MX Adapter)
+
+on: pull_request
+
+jobs:
+  setup-env:
+    name: "Load ENV Vars"
+    uses: ./.github/workflows/setup-env.yml
+    secrets: inherit
+
+  e2e-tests-mx-adapter:
+    runs-on: ubuntu-latest
+    needs: [setup-env]
+
+    services:
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+        options: --health-cmd="curl --silent --fail localhost:9200/_cluster/health || exit 1" --health-interval=10s --health-timeout=5s --health-retries=5
+        ports:
+          - 9200:9200
+          - 9300:9300
+        env:
+          discovery.type: single-node
+          xpack.security.enabled: false
+
+      redis:
+        image: redis:7.2-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 20s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - "${{vars.REDIS_PORT}}:${{vars.REDIS_PORT}}"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure sysctl limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/Iron"
+          check-latest: true
+      - run: npm ci
+
+      - run: npm run copyMXTestPreferences
+
+      - name: "Create env file"
+        run: |
+          ENV_FILE_PATH=./apps/server/.env
+          touch ${ENV_FILE_PATH}
+
+          # Vars
+          echo -e "${{ needs.setup-env.outputs.env_vars }}" >> ${ENV_FILE_PATH}
+
+          # Secrets (can't load these from another job, due to GH security features)
+          echo MX_CLIENT_ID=${{ secrets.MX_CLIENT_ID }} >> ${ENV_FILE_PATH}
+          echo MX_API_SECRET=${{ secrets.MX_API_SECRET }} >> ${ENV_FILE_PATH}
+          echo MX_CLIENT_ID_PROD=${{ secrets.MX_CLIENT_ID_PROD }} >> ${ENV_FILE_PATH}
+          echo MX_API_SECRET_PROD=${{ secrets.MX_API_SECRET_PROD }} >> ${ENV_FILE_PATH}
+          echo DELETE_USER_ENDPOINT_ENABLE=true >> ${ENV_FILE_PATH}
+          echo PROXY_USERNAME=${{ secrets.PROXY_USERNAME }} >> ${ENV_FILE_PATH}
+          echo PROXY_PASSWORD=${{ secrets.PROXY_PASSWORD }} >> ${ENV_FILE_PATH}
+
+      - name: Cypress run
+        uses: cypress-io/github-action@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config-file: cypress.config.ts
+          project: packages/mx-adapter
+          start: npm run start:e2e
+          wait-on: "http://localhost:8080/health, http://localhost:9200"
+          spec: cypress/e2e/proxy/axiosProxy.cy.ts
+
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: ./packages/mx-adapter/cypress/screenshots

--- a/.github/workflows/e2e-cypress-mx-adapter-proxy.yml
+++ b/.github/workflows/e2e-cypress-mx-adapter-proxy.yml
@@ -1,4 +1,4 @@
-name: E2E Tests (MX Adapter)
+name: Proxy Server E2E Tests (MX Adapter)
 
 on: pull_request
 
@@ -74,11 +74,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          config-file: cypress.config.ts
+          config-file: cypress.config.proxy.ts
           project: packages/mx-adapter
           start: npm run start:e2e
           wait-on: "http://localhost:8080/health, http://localhost:9200"
-          spec: cypress/e2e/proxy/axiosProxy.cy.ts
 
       - name: Upload screenshots
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e-cypress-mx-adapter-proxy.yml
+++ b/.github/workflows/e2e-cypress-mx-adapter-proxy.yml
@@ -68,6 +68,8 @@ jobs:
           echo DELETE_USER_ENDPOINT_ENABLE=true >> ${ENV_FILE_PATH}
           echo PROXY_USERNAME=${{ secrets.PROXY_USERNAME }} >> ${ENV_FILE_PATH}
           echo PROXY_PASSWORD=${{ secrets.PROXY_PASSWORD }} >> ${ENV_FILE_PATH}
+          echo PROXY_HOST=velodrome.usefixie.com >> ${ENV_FILE_PATH}
+          echo PROXY_PORT=80 >> ${ENV_FILE_PATH}
 
       - name: Cypress run
         uses: cypress-io/github-action@v6

--- a/package-lock.json
+++ b/package-lock.json
@@ -20717,7 +20717,7 @@
     },
     "packages/mx-adapter": {
       "name": "@ucp-npm/mx-adapter",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@repo/utils": "*",

--- a/packages/mx-adapter/cypress.config.proxy.ts
+++ b/packages/mx-adapter/cypress.config.proxy.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "cypress";
+import baseCypressConfig from "./cypress.config.base.ts";
+
+export default defineConfig({
+  ...baseCypressConfig,
+  e2e: {
+    ...baseCypressConfig.e2e,
+    specPattern: "cypress/e2e/proxy/*.{js,jsx,ts,tsx}",
+  },
+});

--- a/packages/mx-adapter/cypress/e2e/mx.cy.ts
+++ b/packages/mx-adapter/cypress/e2e/mx.cy.ts
@@ -1,24 +1,14 @@
 import { JobTypes } from "@repo/utils";
 import {
-  clickContinue,
-  expectConnectionSuccess,
   generateDataTests,
   refreshAConnection,
   visitWithPostMessageSpy,
 } from "@repo/utils-dev-dependency";
-import { enterMxCredentials, searchAndSelectMx } from "../utils/mx";
-
-const makeAConnection = async (jobType) => {
-  searchAndSelectMx();
-  enterMxCredentials();
-  clickContinue();
-
-  if ([JobTypes.ALL, JobTypes.VERIFICATION].includes(jobType)) {
-    cy.findByText("Checking").click();
-    clickContinue();
-  }
-  expectConnectionSuccess();
-};
+import {
+  enterMxCredentials,
+  makeAConnection,
+  searchAndSelectMx,
+} from "../utils/mx";
 
 describe("mx aggregator", () => {
   generateDataTests({ makeAConnection, shouldTestVcEndpoint: true });

--- a/packages/mx-adapter/cypress/e2e/proxy/axiosProxy.cy.ts
+++ b/packages/mx-adapter/cypress/e2e/proxy/axiosProxy.cy.ts
@@ -1,0 +1,49 @@
+import {
+  searchByText,
+  verifyAccountsAndReturnAccountId,
+  visitAgg,
+  visitWithPostMessageSpy,
+} from "@repo/utils-dev-dependency";
+import { makeAConnection } from "../../utils/mx";
+
+describe("mx aggregator using axios proxy", () => {
+  it("gets data through the proxy server", () => {
+    let memberGuid: string;
+    let aggregator: string;
+    const shouldTestVcEndpoint = false;
+    const userId = Cypress.env("userId");
+
+    visitWithPostMessageSpy(`/widget?job_type=aggregate&user_id=${userId}`)
+      .then(() => makeAConnection("aggregate"))
+      .then(() => {
+        // Capture postmessages into variables
+        cy.get("@postMessage", { timeout: 90000 }).then((mySpy) => {
+          const connection = (mySpy as any)
+            .getCalls()
+            .find(
+              (call) => call.args[0].type === "vcs/connect/memberConnected",
+            );
+          const { metadata } = connection?.args[0];
+          memberGuid = metadata.member_guid;
+          aggregator = metadata.aggregator;
+
+          verifyAccountsAndReturnAccountId({
+            memberGuid,
+            aggregator,
+            shouldTestVcEndpoint,
+            userId,
+          });
+        });
+      });
+  });
+
+  it("gets institution credentials from Prod institution through the proxy server", () => {
+    const userId = Cypress.env("userId");
+
+    visitAgg({ userId });
+    searchByText("Capital One");
+
+    cy.findByLabelText("Add account with Capital One").first().click();
+    cy.findByText("Sign in with Capital One").should("exist");
+  });
+});

--- a/packages/mx-adapter/cypress/utils/mx.ts
+++ b/packages/mx-adapter/cypress/utils/mx.ts
@@ -1,4 +1,10 @@
-import { searchByText } from "@repo/utils-dev-dependency";
+import { JobTypes } from "@repo/utils";
+
+import {
+  clickContinue,
+  expectConnectionSuccess,
+  searchByText,
+} from "@repo/utils-dev-dependency";
 
 export const searchAndSelectMx = () => {
   searchByText("MX Bank");
@@ -8,4 +14,16 @@ export const searchAndSelectMx = () => {
 export const enterMxCredentials = () => {
   cy.findByLabelText("LOGIN").type("mxuser");
   cy.findByLabelText("PASSWORD").type("correct");
+};
+
+export const makeAConnection = async (jobType) => {
+  searchAndSelectMx();
+  enterMxCredentials();
+  clickContinue();
+
+  if ([JobTypes.ALL, JobTypes.VERIFICATION].includes(jobType)) {
+    cy.findByText("Checking").click();
+    clickContinue();
+  }
+  expectConnectionSuccess();
 };

--- a/packages/mx-adapter/package.json
+++ b/packages/mx-adapter/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "dev": "nodemon",
     "cypress:open": "cypress open --config-file cypress.config.ts",
+    "cypress:open:proxy": "cypress open --config-file cypress.config.proxy.ts",
     "cypress:run": "cypress run --config-file cypress.config.ts",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",

--- a/packages/mx-adapter/package.json
+++ b/packages/mx-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucp-npm/mx-adapter",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "MX Adapter for the Universal Connect Widget",
   "packageManager": "npm@10.8.2",
   "main": "dist/cjs/index.js",

--- a/packages/mx-adapter/package.json
+++ b/packages/mx-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucp-npm/mx-adapter",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "MX Adapter for the Universal Connect Widget",
   "packageManager": "npm@10.8.2",
   "main": "dist/cjs/index.js",

--- a/packages/mx-adapter/src/adapter.ts
+++ b/packages/mx-adapter/src/adapter.ts
@@ -83,7 +83,10 @@ export class MxAdapter implements WidgetAdapter {
     this.aggregator = int ? "mx_int" : "mx";
     this.apiClient = int
       ? MxIntApiClient(dependencies?.aggregatorCredentials.mxInt)
-      : MxProdApiClient(dependencies?.aggregatorCredentials.mxProd);
+      : MxProdApiClient({
+          aggregatorCredentials: dependencies?.aggregatorCredentials.mxProd,
+          envConfig: dependencies?.envConfig,
+        });
     this.cacheClient = dependencies?.cacheClient;
     this.logClient = dependencies?.logClient;
     this.envConfig = dependencies?.envConfig;

--- a/packages/mx-adapter/src/apiClient.test.ts
+++ b/packages/mx-adapter/src/apiClient.test.ts
@@ -1,0 +1,59 @@
+import axios from "mx-platform-node/node_modules/axios";
+import { MxProdApiClient } from "./apiClient";
+import type { ApiCredentials } from "./models";
+
+jest.mock("mx-platform-node", () => ({
+  MxPlatformApiFactory: jest.fn(),
+  Configuration: jest.fn(),
+}));
+
+describe("MxProdApiClient", () => {
+  const mockAggregatorCredentials: ApiCredentials = {
+    clientId: "test-client-id",
+    apiKey: "test-api-key",
+  };
+
+  const mockEnvConfigWithProxy = {
+    PROXY_HOST: "velodrome.usefixie.com",
+    PROXY_PORT: "80",
+    PROXY_USERNAME: "fixie",
+    PROXY_PASSWORD: "DB4ERlidGtqEU51",
+  };
+
+  const mockEnvConfigWithoutProxy = {};
+
+  it("creates an API client with proxy configuration when PROXY_HOST is defined", () => {
+    const axiosCreateSpy = jest.spyOn(axios, "create");
+
+    MxProdApiClient({
+      aggregatorCredentials: mockAggregatorCredentials,
+      envConfig: mockEnvConfigWithProxy,
+    });
+
+    expect(axiosCreateSpy).toHaveBeenCalledWith({
+      proxy: {
+        host: mockEnvConfigWithProxy.PROXY_HOST,
+        port: parseInt(mockEnvConfigWithProxy.PROXY_PORT),
+        auth: {
+          username: mockEnvConfigWithProxy.PROXY_USERNAME,
+          password: mockEnvConfigWithProxy.PROXY_PASSWORD,
+        },
+      },
+    });
+
+    axiosCreateSpy.mockRestore();
+  });
+
+  it("creates an API client without proxy configuration when PROXY_HOST is not defined", () => {
+    const axiosCreateSpy = jest.spyOn(axios, "create");
+
+    MxProdApiClient({
+      aggregatorCredentials: mockAggregatorCredentials,
+      envConfig: mockEnvConfigWithoutProxy,
+    });
+
+    expect(axiosCreateSpy).not.toHaveBeenCalled();
+
+    axiosCreateSpy.mockRestore();
+  });
+});

--- a/packages/mx-adapter/src/apiClient.test.ts
+++ b/packages/mx-adapter/src/apiClient.test.ts
@@ -2,11 +2,6 @@ import axios from "mx-platform-node/node_modules/axios";
 import { MxProdApiClient } from "./apiClient";
 import type { ApiCredentials } from "./models";
 
-jest.mock("mx-platform-node", () => ({
-  MxPlatformApiFactory: jest.fn(),
-  Configuration: jest.fn(),
-}));
-
 describe("MxProdApiClient", () => {
   const mockAggregatorCredentials: ApiCredentials = {
     clientId: "test-client-id",
@@ -14,10 +9,10 @@ describe("MxProdApiClient", () => {
   };
 
   const mockEnvConfigWithProxy = {
-    PROXY_HOST: "velodrome.usefixie.com",
+    PROXY_HOST: "fakehost.server.com",
     PROXY_PORT: "80",
-    PROXY_USERNAME: "fixie",
-    PROXY_PASSWORD: "DB4ERlidGtqEU51",
+    PROXY_USERNAME: "username",
+    PROXY_PASSWORD: "password",
   };
 
   const mockEnvConfigWithoutProxy = {};

--- a/packages/mx-adapter/src/apiClient.test.ts
+++ b/packages/mx-adapter/src/apiClient.test.ts
@@ -35,8 +35,6 @@ describe("MxProdApiClient", () => {
         },
       },
     });
-
-    axiosCreateSpy.mockRestore();
   });
 
   it("creates an API client without proxy configuration when PROXY_HOST is not defined", () => {
@@ -48,7 +46,5 @@ describe("MxProdApiClient", () => {
     });
 
     expect(axiosCreateSpy).not.toHaveBeenCalled();
-
-    axiosCreateSpy.mockRestore();
   });
 });

--- a/packages/mx-adapter/src/apiClient.ts
+++ b/packages/mx-adapter/src/apiClient.ts
@@ -1,13 +1,33 @@
 import { Configuration, MxPlatformApiFactory } from "mx-platform-node";
 
-import { basePathProd, basePathInt } from "./consts";
+import axios from "mx-platform-node/node_modules/axios";
+import { basePathInt, basePathProd } from "./consts";
 import type { ApiCredentials } from "./models";
 
 export const BASE_PATH = "https://api.mx.com".replace(/\/+$/, "");
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const MxProdApiClient: any = (aggregatorCredentials: ApiCredentials) =>
-  MxPlatformApiFactory(
+export const MxProdApiClient: any = ({
+  aggregatorCredentials,
+  envConfig,
+}: {
+  aggregatorCredentials: ApiCredentials;
+  envConfig?: Record<string, string>;
+}) => {
+  const axiosWithProxy = envConfig.PROXY_HOST
+    ? axios.create({
+        proxy: {
+          host: envConfig.PROXY_HOST,
+          port: parseInt(envConfig.PROXY_PORT),
+          auth: {
+            username: envConfig.PROXY_USERNAME,
+            password: envConfig.PROXY_PASSWORD,
+          },
+        },
+      })
+    : undefined;
+
+  return MxPlatformApiFactory(
     new Configuration({
       ...aggregatorCredentials,
       basePath: basePathProd,
@@ -17,7 +37,10 @@ export const MxProdApiClient: any = (aggregatorCredentials: ApiCredentials) =>
         },
       },
     }),
+    basePathProd,
+    axiosWithProxy,
   );
+};
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const MxIntApiClient: any = (aggregatorCredentials: ApiCredentials) =>

--- a/packages/mx-adapter/src/createVc.ts
+++ b/packages/mx-adapter/src/createVc.ts
@@ -13,7 +13,7 @@ const createMXGetVC =
   (isProd: boolean, dependencies: VCDependencies) =>
   async ({ connectionId, type, userId, accountId }: DataParameters) => {
     let path = "";
-    const { logClient, aggregatorCredentials } = dependencies;
+    const { logClient, aggregatorCredentials, envConfig } = dependencies;
 
     switch (type) {
       case VCDataTypes.IDENTITY:
@@ -34,6 +34,7 @@ const createMXGetVC =
     return await getVC(path, isProd, {
       logClient,
       aggregatorCredentials,
+      envConfig,
     });
   };
 

--- a/packages/mx-adapter/src/getVc.test.ts
+++ b/packages/mx-adapter/src/getVc.test.ts
@@ -105,8 +105,7 @@ describe("mx vc", () => {
 
       const response = await getVC(accountsPath, false, dependencies);
 
-      await getVC(accountsPath, true, dependencies),
-        expect(axiosCreateSpy).not.toHaveBeenCalled();
+      expect(axiosCreateSpy).not.toHaveBeenCalled();
 
       expect(response).toEqual(mxVcAccountsData);
     });

--- a/packages/mx-adapter/src/getVc.ts
+++ b/packages/mx-adapter/src/getVc.ts
@@ -1,6 +1,6 @@
-import get from "axios";
+import axios from "mx-platform-node/node_modules/axios";
 
-import { basePathProd, basePathInt } from "./consts";
+import { basePathInt, basePathProd } from "./consts";
 import type { VCDependencies } from "./models";
 
 export const getVC = async (
@@ -8,7 +8,7 @@ export const getVC = async (
   isProd: boolean,
   dependencies: VCDependencies,
 ): Promise<any> => {
-  const { logClient, aggregatorCredentials } = dependencies;
+  const { logClient, aggregatorCredentials, envConfig } = dependencies;
 
   const configuration = isProd
     ? aggregatorCredentials.mxProd
@@ -22,7 +22,20 @@ export const getVC = async (
 
   const url = `${isProd ? basePathProd : basePathInt}/vc/${path}`;
 
-  return get({
+  const axiosConfigured = dependencies?.envConfig.PROXY_HOST
+    ? axios.create({
+        proxy: {
+          host: envConfig.PROXY_HOST,
+          port: parseInt(envConfig.PROXY_PORT),
+          auth: {
+            username: envConfig.PROXY_USERNAME,
+            password: envConfig.PROXY_PASSWORD,
+          },
+        },
+      })
+    : axios;
+
+  return axiosConfigured({
     url,
     headers: {
       Accept: "application/vnd.mx.api.v1beta+json",

--- a/packages/mx-adapter/src/models.ts
+++ b/packages/mx-adapter/src/models.ts
@@ -2,7 +2,7 @@ export type ApiCredentials = {
   username?: string;
   password?: string;
   [key: string]: any;
-}
+};
 
 export type CacheClient = {
   set: (key: string, value: any) => Promise<void> | void;
@@ -15,21 +15,22 @@ export type LogClient = {
   debug: (message: string, data?: any) => void;
   trace: (message: string, data?: any) => void;
   warning: (message: string, data?: any) => void;
-}
+};
 
 export type AdapterDependencies = {
   cacheClient: CacheClient;
   logClient: LogClient;
   aggregatorCredentials: Record<string, ApiCredentials>;
   envConfig: Record<string, string>;
-}
+};
 
 export type AdapterConfig = {
   int: boolean;
   dependencies: AdapterDependencies;
-}
+};
 
 export type VCDependencies = {
   logClient: LogClient;
   aggregatorCredentials: any;
+  envConfig: Record<string, string>;
 };

--- a/packages/utils-dev-dependency/cypress/generateDataTests.ts
+++ b/packages/utils-dev-dependency/cypress/generateDataTests.ts
@@ -7,7 +7,7 @@ const decodeVcDataFromResponse = (response) => {
   return decodeVcData(response.body.jwt);
 };
 
-const verifyAccountsAndReturnAccountId = ({
+export const verifyAccountsAndReturnAccountId = ({
   aggregator,
   memberGuid,
   shouldTestVcEndpoint,


### PR DESCRIPTION
Gives an option of passing a proxy server into the MX production api client to help make it possible to have static IPs in heroku deployments of the ucw-app. Which is necessary to interact with MX production.